### PR TITLE
Make sure that the settings subsystem is initialized

### DIFF
--- a/src/provision.c
+++ b/src/provision.c
@@ -145,6 +145,12 @@ int thingsboard_provision_device(const char *device_name, token_callback cb) {
 
 	token_cb = cb;
 
+	err = settings_subsys_init();
+	if (err) {
+		LOG_ERR("Failed to initialize settings subsystem, error (%d): %s", err, strerror(-err));
+		return err;
+	}
+
 	err = settings_load();
 	if (err) {
 		LOG_ERR("Could not load settings");


### PR DESCRIPTION
So far this was the user's responsibility but it wasn't documented anywhere. It doesn't hurt to call `settings_subsys_init()` repeatedly so the SDK does it itself now before trying to load any settings.