### PR TITLE
Handle non-piggybacked responses

### DIFF
--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -342,10 +342,10 @@ static int client_handle_get_response(uint8_t *buf, int received, struct sockadd
 	}
 
 	/*
-	 * In a piggybacked response, message ID and token must match.
+	 * Handle responses (piggybacked and non-piggybacked)
 	 */
 	COAP_FOR_EACH_REQUEST_SAFE(r, rs) {
-		if (r->id == id && !memcmp(r->token, token, tkl)) {
+		if (!memcmp(r->token, token, tkl)) {
 			if (r->reply_handler) {
 				r->reply_handler(r, &response);
 			}

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -312,8 +312,8 @@ static int client_handle_get_response(uint8_t *buf, int received, struct sockadd
 		 * RFC7252 5.3.2
 		 */
 		COAP_FOR_EACH_REQUEST_SAFE(r, rs) {
-			if (r->confirmable && r->id == id) {
-				r->confirmable = false;
+			if (r->confirmable && !r->confirmed && r->id == id) {
+				r->confirmed = true;
 				if (r->reply_handler) {
 					/*
 					 * We expect a reply -


### PR DESCRIPTION
Looks like thingsboard might respond to the getCurrentTime RPC call with an ACK plus a separate response instead of a piggybacked response. The response handler only worked with piggybacked responses so far.