### PR TITLE
Add all dependencies to Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -49,11 +49,15 @@ config THINGSBOARD_USE_PROVISIONING
     depends on NVS
 	default y
 
+if THINGSBOARD_USE_PROVISIONING
+
 config THINGSBOARD_PROVISIONING_KEY
     string "Provisioning key"
 
 config THINGSBOARD_PROVISIONING_SECRET
     string "Provisioning secret"
+
+endif # THINGSBOARD_USE_PROVISIONING
 
 config THINGSBOARD_ACCESS_TOKEN
   string
@@ -82,4 +86,4 @@ module = THINGSBOARD
 module-str = Thingsboard SDK
 source "subsys/logging/Kconfig.template.log_config"
 
-endif
+endif # THINGSBOARD

--- a/Kconfig
+++ b/Kconfig
@@ -1,9 +1,11 @@
 menuconfig THINGSBOARD
     bool "Thingsboard library"
-    depends on COAP
+    depends on NETWORKING
+    depends on NET_IPV4
     depends on NET_SOCKETS
-    depends on NET_SOCKETS_POSIX_NAMES
     depends on JSON_LIBRARY
+    depends on COAP
+    select NET_SOCKETS_POSIX_NAMES
 
 if THINGSBOARD
 
@@ -41,6 +43,11 @@ config COAP_NUM_RETRIES
 
 config THINGSBOARD_USE_PROVISIONING
     bool "Provision devices"
+    depends on SETTINGS
+    depends on FLASH
+    depends on FLASH_MAP
+    depends on NVS
+	default y
 
 config THINGSBOARD_PROVISIONING_KEY
     string "Provisioning key"

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,4 @@
+name: thingsboard-sdk
 build:
   cmake: .
   kconfig: Kconfig


### PR DESCRIPTION
Add all the dependencies to Kconfig (using `depends on`) so that the user does not have to guess these.