### PR TITLE
Set content format in CoAP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ port of the Thingsboard CoAP server, using `config COAP_CLIENT_NUM_MSGS` and `co
 CoAP reliability can be fine-tuned using `config COAP_NUM_RETRIES` and the Zephyr-internal `config
 COAP_INIT_ACK_TIMEOUT_MS`. Using NB-IoT, 15000 is a good starting value for the latter.
 
+### Device Profile
+
+The SDK currently only supports CoAP with JSON payload as transport type. This works with the default device profile of Thingsboard.
+If you create a custom device profile make sure to configure it accordingly.
+
 ### Sending telemetry to cloud
 
 ```c
@@ -95,7 +100,7 @@ int thingsboard_send_telemetry(const void *payload, size_t sz);
 ```
 
 As outlined in the [official Thingsboard documentation](https://thingsboard.io/docs/user-guide/telemetry/), by default,
-their telemetry endpoint expects a JSON string with values:
+their telemetry endpoint expects a JSON string with key-value pairs:
 
 ```json
 {
@@ -103,8 +108,6 @@ their telemetry endpoint expects a JSON string with values:
   "humidity": 70
 }
 ```
-
-You can also configure your device profile to expect protobuf or custom content encodings.
 
 You can include your own timestamp using the syntax documented by Thingsboard:
 

--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -236,6 +236,14 @@ int coap_client_make_request(const uint8_t **uri, const void *payload, size_t pl
 			LOG_ERR("Failed to append payload, error (%d): %s", err, strerror(-err));
 			goto cleanup;
 		}
+
+		err = coap_append_option_int(&req->pkt, COAP_OPTION_CONTENT_FORMAT,
+					     COAP_CONTENT_FORMAT_APP_JSON);
+		if (err < 0) {
+			LOG_ERR("Failed to append content format option, error (%d): %s", err,
+				strerror(-err));
+			goto cleanup;
+		}
 	}
 
 	return coap_client_send(req, reply);


### PR DESCRIPTION
Thingsboard does not really seem to care about this as the payload format is specified in the device profile.
It makes sense to set it correctly anyway (e.g. because Wireshark uses it to decode the data).
