### PR TITLE
Fix scheduling of receive worker

### DIFF
--- a/src/coap_client.c
+++ b/src/coap_client.c
@@ -646,7 +646,7 @@ static void on_work(struct k_work *work)
 		client_state_set(COAP_CLIENT_ERROR);
 	}
 
-	err = k_work_schedule(&work_coap, APP_RECEIVE_INTERVAL);
+	err = k_work_reschedule(&work_coap, APP_RECEIVE_INTERVAL);
 	if (err < 0) {
 		LOG_ERR("Failed to schedule receiver, error (%d): %s", err, strerror(-err));
 	}


### PR DESCRIPTION
client_cycle_requests reschedules the coap worker. Afterwards the worker is scheduled again with a delay of APP_RECEIVE_INTERVAL which did not have any effect because k_work_schedule() instead of k_work_reschedule was used.
The result was that after sending a request the worker did not run for a few seconds and therefore received the response too late, leading to a retransmission of the request.